### PR TITLE
Fix Github Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,3 @@
-
-
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/ISSUE_TEMPLATE/small_issue.md
+++ b/.github/ISSUE_TEMPLATE/small_issue.md
@@ -1,4 +1,3 @@
-
 ---
 name: Task
 about: A small task that is, most likely, part of an Epic. It will usually be labeled as `good first issue`.


### PR DESCRIPTION
# Story Title

[Bug: Issue Templates Not Loading](https://github.com/craigardy/spotifyrelease/issues/9#issue-2754213807)

## Changes made

- Updated bug_report.md and small_issue.md to fix the error where they would not show up as a template when generating a new issue.

## How does the solution address the problem

This PR will enable the bug_report and small_issue to appear as a template when generating a new issue.

## Linked issues

Resolves #9 
